### PR TITLE
Fixes concatenation issue caused by missing end semi-colon

### DIFF
--- a/uuid.js
+++ b/uuid.js
@@ -39,4 +39,4 @@
 
   exports.uuid = uuid
   exports.isUUID = isUUID
-}))
+}));


### PR DESCRIPTION
I have been using this lib via bower in a project, and when it is concatenated amongst other libs by the useref module, it causes the output to be invalid JS, e.g.:

``` javascript
}))(function() {...
```

This is because uuid.js is listed as the main file in your bower.js, but it does not end with a semi-colon, so I have added one.
